### PR TITLE
Json schema epcis snippets

### DIFF
--- a/json-schema-epcis-profiles/_specifications.md
+++ b/json-schema-epcis-profiles/_specifications.md
@@ -1,0 +1,50 @@
+# Specifications for JSON Schema EPCIS Profiles
+
+STATUS: TO BE CONFIRMED
+
+## Naming conventions
+
+Concatenated string consisting of:
+{issuer} + ´_´ + {document type} + ´_´ + {document acronym} + ´_´ + {document release} + ´_´ + {profile name} + ´_´ + {profile counter} + '.json'
+
+### `Issuer`
+
+* Organisation which defined the profile
+* Up to 10 capital letters or digits
+
+### `Document type` (non-normative)
+
+| **Document type**  | **Definition**                    |
+|:------------------:|:---------------------------------:|
+| AS                 | Application Standard              |
+| IG                 | Implementation Guideline          |
+| CS                 | Industry Consortium Specification |
+| ES                 | Enterprise Specification          |
+| RD                 | Research Document                 |
+| WP                 | White Paper                       |
+| GP                 | Green Paper                       |
+
+### `Document acronym`
+
+* Up to 6 capital letters or digits
+
+### `Document release`
+
+* Release version, separated by "dot" to delimit e.g. major/minor/patch release, if applicable  
+
+### `Profile name`
+
+* alphanumeric string, consisting of up to 30 letters or digits 
+* starting with an upper case
+* expressed in camelcase in case it consists of several words
+
+### `Profile counter`
+
+* integer
+
+### JSON Schema EPCIS Profile Name Examples (for illustration purposes only)
+
+* “GS1_AS_FIT_1dot1_ApplyingUnitLevelUIs_1.json” (GS1, Application Standard, Fighting Illicit Trade with EPCIS Application Standard, Release 1.1, Application of unit level UIs on unit packets, Profile #1)
+* “GS1DE_GP_EUDR_1dot0_OriginDeclarationEvent_2.json” (GS1 Germany, Green Paper, Green Paper: How GS1 Standards can help to meet the EU Deforestation Regulation, Release 1.0, Origin Declaration Event, Profile #2)
+
+Files MAY be removed.

--- a/json-schema-epcis-snippets/_specifications.md
+++ b/json-schema-epcis-snippets/_specifications.md
@@ -1,0 +1,34 @@
+# Specifications for JSON Schema EPCIS Snippets
+
+STATUS: TO BE CONFIRMED
+
+## Naming conventions
+
+Concatenated string consisting of:
+{JSON Schema EPCIS Snippet name} + ´-´ + {Major version} + ´.´ + {Minor version} + ´.´ + {Patch version} + '.json'
+
+### `JSON Schema EPCIS Snippet Name`
+
+* alphanumeric string consisting of lowercase letters
+* separated by a hyphen/dash character ('-') if consisting of several words (kekab case)
+
+### JSON Schema EPCIS Snippet Name Examples (for illustration purposes only)
+
+* "quantity-uom-all-1.0.0.json"
+* "quantity-uom-length-1.0.0.json"
+* "epc-uri-sgtin-0.1.0.json"
+* "example-extension-field-string-value-1.0.1.json"
+
+Files MUST NOT be removed.
+
+## Best practice to fill description
+
+Apply the following 'recipe' to fill in the `description` property:
+
+* > `Specifies value | set of values for` {indicate EPCIS field name(s)}
+* > `,` `expressed as` {specify type and/or format}
+* > [optional] `,` `relevant for` {insert applicable industry domain(s)} | `for illustration`
+* > [optional] `,` `note` {provide additional context, if appliable} `.`
+
+Ideally, formulate description in the specified sequence.
+  

--- a/json-schema-epcis-snippets/epc-class-uri-lgtin-0.1.0.json
+++ b/json-schema-epcis-snippets/epc-class-uri-lgtin-0.1.0.json
@@ -1,0 +1,12 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/epc-class-uri-lgtin-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies value for the epcClass field as part of the quantityList, childQuantityList, inputQuantityList, or outputQuantityList, expressed as an LGTIN EPC Class URI (URN), relevant for all sectors.",
+    "title": "LGTIN EPC Class URI",
+    "definitions": {
+        "epc-class-uri-lgtin": {
+            "type": "string",
+            "pattern": "^urn:epc:class:lgtin:((\\d{6}\\.\\d{7})|(\\d{7}\\.\\d{6})|(\\d{8}\\.\\d{5})|(\\d{9}\\.\\d{4})|(\\d{10}\\.\\d{3})|(\\d{11}\\.\\d{2})|(\\d{12}\\.\\d{1}))\\.(\\%2[125-9A-Fa-f]|\\%3[0-9A-Fa-f]|\\%4[1-9A-Fa-f]|\\%5[0-9AaFf]|\\%6[1-9A-Fa-f]|\\%7[0-9Aa]|[!\\')(*+,.0-9:;=A-Za-z_-]){1,20}$"
+        }
+    }
+}

--- a/json-schema-epcis-snippets/epc-uri-all-0.1.0.json
+++ b/json-schema-epcis-snippets/epc-uri-all-0.1.0.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/epc-uri-all-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "EPC URIs",
+    "description": "Specifies set of values for the epcList, childEPCs or parentID field, expressed as any GS1 Key based EPC scheme in EPC URI (URN) format, relevant for all sectors.",
+    "definitions": {
+        "epc-uri-all": {
+            "oneOf": [{
+                    "$ref": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/epc-uri-sscc-0.1.0.json#/definitions/epc-uri-sscc"
+                },
+                {
+                    "$ref": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/epc-uri-sgtin-0.1.0.json#/definitions/epc-uri-sgtin"
+                }
+            ]
+        }
+    }
+}

--- a/json-schema-epcis-snippets/epc-uri-sgtin-0.1.0.json
+++ b/json-schema-epcis-snippets/epc-uri-sgtin-0.1.0.json
@@ -1,0 +1,12 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/epc-uri-sgtin-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies value for the epcList, childEPCs, inputEPCList, outputEPCList, or parentID field, expressed as a Serialised Global Trade Item Number (SGTIN) in EPC URI (URN) format, relevant for all sectors.",
+    "title": "SGTIN EPC URI",
+    "definitions": {
+        "epc-uri-sgtin": {
+            "type": "string",
+            "pattern": "^urn:epc:id:sgtin:((\\d{6}\\.\\d{7})|(\\d{7}\\.\\d{6})|(\\d{8}\\.\\d{5})|(\\d{9}\\.\\d{4})|(\\d{10}\\.\\d{3})|(\\d{11}\\.\\d{2})|(\\d{12}\\.\\d{1}))\\.(\\%2[125-9A-Fa-f]|\\%3[0-9A-Fa-f]|\\%4[1-9A-Fa-f]|\\%5[0-9AaFf]|\\%6[1-9A-Fa-f]|\\%7[0-9Aa]|[!\\')(*+,.0-9:;=A-Za-z_-]){1,20}$"
+        }
+    }
+}

--- a/json-schema-epcis-snippets/epc-uri-sscc-0.1.0.json
+++ b/json-schema-epcis-snippets/epc-uri-sscc-0.1.0.json
@@ -1,0 +1,12 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/epc-uri-sscc-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies value for the epcList, childEPCs or parentID field, expressed as a Serial Shipping Container Code (SSCC) in EPC URI (URN) format, relevant for all sectors.",
+    "title": "SSCC EPC URI",
+    "definitions": {
+        "epc-uri-sscc": {
+            "type": "string",
+            "pattern": "^urn:epc:id:sscc:((\\d{6}\\.\\d{11}$)|(\\d{7}\\.\\d{10}$)|(\\d{8}\\.\\d{9}$)|(\\d{9}\\.\\d{8}$)|(\\d{10}\\.\\d{7}$)|(\\d{11}\\.\\d{6}$)|(\\d{12}\\.\\d{5}$))"
+        }
+    }
+}

--- a/json-schema-epcis-snippets/example-custom-bizsteps-0.1.0.json
+++ b/json-schema-epcis-snippets/example-custom-bizsteps-0.1.0.json
@@ -1,0 +1,16 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/example-custom-bizsteps-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies set of values for the bizStep field, expressed as user-defined placeholder values using the 'example.com' domain, for illustration, note that 'example.com' and custom code values need to be replaced with your own ones.",
+    "title": "Example custom bizstep code values",
+    "definitions": {
+        "example-custom-bizsteps": {
+            "type": "string",
+            "enum": [
+                "https://epcis.example.com/bizstep/washing",
+                "https://epcis.example.com/bizstep/cutting",
+                "https://epcis.example.com/bizstep/blow_drying"
+            ]
+        }
+    }
+}

--- a/json-schema-epcis-snippets/gs1dl-uri-sscc-0.1.0.json
+++ b/json-schema-epcis-snippets/gs1dl-uri-sscc-0.1.0.json
@@ -1,0 +1,12 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/gs1dl-uri-sscc-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies value for the epcList, childEPCs or parentID field, expressed as a Serial Shipping Container Code (SSCC) in GS1 Digital Link Web URI format, relevant for all sectors.",
+    "title": "SSCC GS1 Digital Link URI",
+    "definitions": {
+        "gs1dl-uri-sscc": {
+            "type": "string",
+            "pattern": "^(https?):(\/\/((([^\/?#]*)@)?([^\/?#:]*)(:([^\/?#]*))?))?([^?#]*)(\/00\/)\\d{18}$"
+        }
+    }
+}

--- a/json-schema-epcis-snippets/quantity-uom-all-0.1.0.json
+++ b/json-schema-epcis-snippets/quantity-uom-all-0.1.0.json
@@ -1,0 +1,23 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-all-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies set of values for the uom field in a QuantityElement, expressed as a 2- or 3-character unit code for area, length, mass or volume, relevant for all sectors, note: from UN/CEFACT Rec. 20.",
+    "title": "Unit codes for area, length, mass and volume, based on UN/CEFACT Rec. 20",
+    "definitions": {
+        "quantity-uom-all": {
+            "oneOf": [{
+                    "$ref": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-area-0.1.0.json#/definitions/quantity-uom-area"
+                },
+                {
+                    "$ref": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-length-0.1.0.json#/definitions/quantity-uom-length"
+                },
+                {
+                    "$ref": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-mass-0.1.0.json#/definitions/quantity-uom-mass"
+                },
+                {
+                    "$ref": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-volume-0.1.0.json#/definitions/quantity-uom-volume"
+                }
+            ]
+        }
+    }
+}

--- a/json-schema-epcis-snippets/quantity-uom-area-0.1.0.json
+++ b/json-schema-epcis-snippets/quantity-uom-area-0.1.0.json
@@ -1,0 +1,14 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-area-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies set of values for the uom field in a QuantityElement, expressed as a 2- or 3-character area unit code, relevant for packaging, technical industries, apparel, etc., note: from UN/CEFACT Rec. 20, e.g., 'MTK' for 'square metre'.",
+    "title": "Unit codes for area, based on UN/CEFACT Rec. 20",
+    "definitions": {
+        "quantity-uom-area": {
+            "type": "string",
+            "enum": [
+                "MTK", "KMK", "H30", "DAA", "CMK", "DMK", "H16", "H18", "MMK", "ARE", "HAR", "INK", "FTK", "YDK", "MIK", "M48", "ACR", "M47", "BB"
+            ]
+        }
+    }
+}

--- a/json-schema-epcis-snippets/quantity-uom-length-0.1.0.json
+++ b/json-schema-epcis-snippets/quantity-uom-length-0.1.0.json
@@ -1,0 +1,15 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-length-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies set of values for the uom field in a QuantityElement, expressed as a 2- or 3-character length unit code, relevant for technical industries, apparel, etc., note: from UN/CEFACT Rec. 20, e.g., 'MTR' for 'metre'.",
+    "title": "Unit codes for length, based on UN/CEFACT Rec. 20",
+    "definitions": {
+        "quantity-uom-length": {
+            "type": "string",
+            "enum": [
+                "MTR", "A11", "A71", "C45", "4H", "A12", "DMT", "CMT", "MMT", "INH", "FOT", "YRD", "NMI", "A45", "HMT", "KMT", "B57", "AK", "M50", "M49", "X1", "M51", "HL", "LF", "LK", "LM", "SMI"
+            ],
+            "deprecated": true
+        }
+    }
+}

--- a/json-schema-epcis-snippets/quantity-uom-length-0.2.0.json
+++ b/json-schema-epcis-snippets/quantity-uom-length-0.2.0.json
@@ -1,9 +1,9 @@
 {
     "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-length-0.1.0.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Specifies set of values for the uom field in a QuantityElement, expressed as a 2- or 3-character length unit code, relevant for technical industries, apparel, packaging, etc., note: from UN/CEFACT Rec. 20, e.g., 'MTR' for 'metre'.",
     "title": "Unit codes for length, based on UN/CEFACT Rec. 20",
-    "definitions": {
+    "$defs": {
         "quantity-uom-length": {
             "type": "string",
             "enum": [

--- a/json-schema-epcis-snippets/quantity-uom-length-0.2.0.json
+++ b/json-schema-epcis-snippets/quantity-uom-length-0.2.0.json
@@ -1,0 +1,14 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-length-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies set of values for the uom field in a QuantityElement, expressed as a 2- or 3-character length unit code, relevant for technical industries, apparel, packaging, etc., note: from UN/CEFACT Rec. 20, e.g., 'MTR' for 'metre'.",
+    "title": "Unit codes for length, based on UN/CEFACT Rec. 20",
+    "definitions": {
+        "quantity-uom-length": {
+            "type": "string",
+            "enum": [
+                "MTR", "A11", "A71", "C45", "4H", "A12", "DMT", "CMT", "MMT", "INH", "FOT", "YRD", "NMI", "A45", "HMT", "KMT", "B57", "AK", "M50", "M49", "X1", "M51", "HL", "LF", "LK", "LM", "SMI"
+            ]
+        }
+    }
+}

--- a/json-schema-epcis-snippets/quantity-uom-mass-0.1.0.json
+++ b/json-schema-epcis-snippets/quantity-uom-mass-0.1.0.json
@@ -1,0 +1,14 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-mass-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies set of values for the uom field in a QuantityElement, expressed as a 2- or 3-character mass unit code, relevant for food, pharma, technical industries, etc., note: from UN/CEFACT Rec. 20, e.g., 'KGM' for 'kilogram'.",
+    "title": "Unit codes for mass, based on UN/CEFACT Rec. 20",
+    "definitions": {
+        "quantity-uom-mass": {
+            "type": "string",
+            "enum": [
+                "KGM", "KTN", "LTN", "2U", "TNE", "STN", "DTN", "STI", "LBR", "HGM", "ONZ", "DJ", "APZ", "GRM", "DG", "CGM", "MGM", "MC", "F13", "CWI", "CWA", "M86", "58", "DRA", "DRI", "E4", "GRN", "PN", "DWT"
+            ]
+        }
+    }
+}

--- a/json-schema-epcis-snippets/quantity-uom-volume-0.1.0.json
+++ b/json-schema-epcis-snippets/quantity-uom-volume-0.1.0.json
@@ -1,0 +1,13 @@
+{
+    "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/quantity-uom-volume-0.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Specifies set of values for the uom field in a QuantityElement, expressed as a 2- or 3-character volume unit code, relevant for food, pharma, technical industries, healthcare, etc., note: from UN/CEFACT Rec. 20, e.g., 'LTR' for 'litre'.",
+    "definitions": {
+        "quantity-uom-volume": {
+            "type": "string",
+            "enum": [
+                "MTQ", "MAL", "LTR", "MMQ", "CMQ", "DMQ", "HLT", "DMA", "H19", "H20", "DLT", "CLT", "MLT", "4G", "Q34", "Q33", "Q32", "K6", "D40", "A44", "INQ", "FTQ", "YDQ", "GLI", "GLL", "PT", "PTI", "QTI", "PTL", "QTL", "PTD", "OZI", "QT", "J57", "L43", "L61", "L62", "L84", "L86", "OZA", "BUI", "BUA", "BLL", "BLD", "GLD", "QTD", "G26", "G21", "G24", "G25", "G23", "M67", "M68", "M69", "M70", "BFT", "BP", "5I", "GIA", "GII", "NM3", "R9", "SM3", "T6", "WCD", "WSD"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Dear @sboeckelmann , 

As discussed last week, I did the following: 

1. Created two folders gathering/organising snippets and profiles.
2. Populated the json-schema-epcis-snippets folder with a couple of first illustrative examples (thereby already applying our discussed recipe).  
3. Inserted two markdown files to collect specifications/rules for the snippets and profiles. 
4. In this regard: our 'recipe' to fill the description property is included in the respective '_specifications.md' document. I took the liberty to slighty tweak it in putting the 'note' keyword (formely at the next to last position) to the end. 
5. Note that I included 'quantity-uom-length-0.1.0.json' and  'quantity-uom-length-0.2.0.json' for two purposes: (a) to explain (in our next call) an idea how we could support update logic and (b) the necessary changes if we want to go for EPCIS schema 2020-12 instead of 07. 

I could not test yet if resolving e.g. <https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/epc-class-uri-lgtin-0.1.0.json> works as nice as in my existing (temporary) repo (e.g. <https://ralphtro.github.io/TEMP_jsonSchemaExperiments/epc-class-uri-lgtin-0.1.0.json>). 

Thanks in advance for your sanity check + for mering it into main.  

@dakbhavesh : FYI. 

Kind regards;
Ralph 