### PR TITLE
Issue-23: reuse the gs1 epcis standard schema

### DIFF
--- a/json-schema-epcis-snippets/action-0.1.0.json
+++ b/json-schema-epcis-snippets/action-0.1.0.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/action-0.1.0.json",
+  "title": "JSON schema for action attribute from EPCIS standard",
+  "description": "Specifies an object containing the action property as defined in the EPCIS standard.",
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": [
+        "OBSERVE",
+        "ADD",
+        "DELETE"
+      ]
+    }
+  },
+  "required": [
+    "action"
+  ],
+  "additionalProperties": false
+}

--- a/json-schema-epcis-snippets/biz-transaction-list-0.1.0.json
+++ b/json-schema-epcis-snippets/biz-transaction-list-0.1.0.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/biz-transaction-list-0.1.0.json",
+  "title": "JSON schema for bizTransactionList attribute from EPCIS standard",
+  "description": "Specifies the bizTransactionList property (array of bizTransaction objects) as part of EPCIS events.",
+  "type": "object",
+  "properties": {
+    "bizTransactionList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/bizTransaction"
+      }
+    }
+  },
+  "required": [
+    "bizTransactionList"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "bizTransaction": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/bizTransaction-type"
+        },
+        "bizTransaction": {
+          "$ref": "#/$defs/uri"
+        }
+      },
+      "required": [
+        "bizTransaction"
+      ],
+      "additionalProperties": false
+    },
+    "bizTransaction-type": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/vocab-other-uri"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "bol",
+            "cert",
+            "desadv",
+            "inv",
+            "pedigree",
+            "po",
+            "poc",
+            "prodorder",
+            "recadv",
+            "rma",
+            "testprd",
+            "testres",
+            "upevt"
+          ]
+        }
+      ]
+    },
+    "vocab-other-uri": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^(?!(urn:epcglobal:cbv|https?:\\/\\/ns\\.gs1\\.org/cbv\\/))"
+    },
+    "uri": {
+      "type": "string",
+      "format": "uri"
+    }
+  }
+}

--- a/json-schema-epcis-snippets/destination-list-0.1.0.json
+++ b/json-schema-epcis-snippets/destination-list-0.1.0.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/destination-list-0.1.0.json",
+  "title": "JSON schema for destinationList attribute from EPCIS standard",
+  "description": "Specifies the destinationList property (array of destination objects) as part of EPCIS events.",
+  "type": "object",
+  "properties": {
+    "destinationList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/destination"
+      }
+    }
+  },
+  "required": [
+    "destinationList"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "destination": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/source-dest-type"
+        },
+        "destination": {
+          "$ref": "#/$defs/uri"
+        }
+      },
+      "required": [
+        "type",
+        "destination"
+      ],
+      "additionalProperties": false
+    },
+    "source-dest-type": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/vocab-other-uri"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "owning_party",
+            "possessing_party",
+            "location"
+          ]
+        }
+      ]
+    },
+    "vocab-other-uri": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^(?!(urn:epcglobal:cbv|https?:\\/\\/ns\\.gs1\\.org/cbv\\/))"
+    },
+    "uri": {
+      "type": "string",
+      "format": "uri"
+    }
+  }
+}


### PR DESCRIPTION
Hi @RalphTro @sboeckelmann @dakbhavesh @nic-bec 

As discussed in our previous call, we wanted to make use of AI to generate JSON Schemas for various EPCIS snippets extracted from the comprehensive GS1 EPCIS standard schema. Based on this, I have tried a system prompt to guide the AI agent in producing the required schemas. I have generated a few sample schema snippets using this prompt, and they appear to be correct. 

For verification and further enhancement, I am attaching three JSON Schema snippets generated by the AI for your reference. Each schema includes a properly constructed title, description, and $id property, as generated by the AI.

Please review these samples and let me know if any modifications or improvements are needed.