### PR TITLE
Create country-code-alpha2-0.1.0.json

### DIFF
--- a/json-schema-epcis-snippets/country-code-alpha2-0.1.0.json
+++ b/json-schema-epcis-snippets/country-code-alpha2-0.1.0.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openepcis.github.io/openepcis-event-sentry/json-schema-epcis-snippets/country-code-alpha2-0.1.0.json",
+  "title": "Country codes based on ISO 3166-1 alpha-2",
+  "description": "Specifies set of values for any EPCIS field expecting a country code, expressed as ISO 3166-1 alpha-2 two-letter codes.",
+  "$defs": {
+    "countryCodeAlpha2": {
+      "type": "string",
+      "enum": [
+        "AD","AE","AF","AG","AI","AL","AM","AO","AQ","AR","AS","AT","AU","AW","AX","AZ",
+        "BA","BB","BD","BE","BF","BG","BH","BI","BJ","BL","BM","BN","BO","BQ","BR","BS","BT","BV","BW","BY","BZ",
+        "CA","CC","CD","CF","CG","CH","CI","CK","CL","CM","CN","CO","CR","CU","CV","CW","CX","CY","CZ",
+        "DE","DJ","DK","DM","DO","DZ",
+        "EC","EE","EG","EH","ER","ES","ET",
+        "FI","FJ","FK","FM","FO","FR",
+        "GA","GB","GD","GE","GF","GG","GH","GI","GL","GM","GN","GP","GQ","GR","GS","GT","GU","GW","GY",
+        "HK","HM","HN","HR","HT","HU",
+        "ID","IE","IL","IM","IN","IO","IQ","IR","IS","IT",
+        "JE","JM","JO","JP",
+        "KE","KG","KH","KI","KM","KN","KP","KR","KW","KY","KZ",
+        "LA","LB","LC","LI","LK","LR","LS","LT","LU","LV","LY",
+        "MA","MC","MD","ME","MF","MG","MH","MK","ML","MM","MN","MO","MP","MQ","MR","MS","MT","MU","MV","MW","MX","MY","MZ",
+        "NA","NC","NE","NF","NG","NI","NL","NO","NP","NR","NU","NZ",
+        "OM",
+        "PA","PE","PF","PG","PH","PK","PL","PM","PN","PR","PS","PT","PW","PY",
+        "QA",
+        "RE","RO","RS","RU","RW",
+        "SA","SB","SC","SD","SE","SG","SH","SI","SJ","SK","SL","SM","SN","SO","SR","SS","ST","SV","SX","SY","SZ",
+        "TC","TD","TF","TG","TH","TJ","TK","TL","TM","TN","TO","TR","TT","TV","TW","TZ",
+        "UA","UG","UM","US","UY","UZ",
+        "VA","VC","VE","VG","VI","VN","VU",
+        "WF","WS",
+        "YE","YT",
+        "ZA","ZM","ZW"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Hi @sboeckelmann , 

As indicated in our last call, I drafted a snippet for ISO 2-alpha country codes. 

If the file looks fine to you, please accept this PR. 

BTW, made a first test to vlidate its applicability:
<img width="1374" height="769" alt="image" src="https://github.com/user-attachments/assets/8c292453-4953-4e18-b62d-41bb2ebf9186" />

See https://github.com/openepcis/openepcis-event-sentry/issues/29 

Kind regards;
Ralph 

@dakbhavesh  and @Aravinda93 : just FYI. 