### PR TITLE
Added  two more profiles

### DIFF
--- a/json-schema-epcis-profiles/ACME_ES_SCE_0dot1_InspectingEventDocument1.json
+++ b/json-schema-epcis-profiles/ACME_ES_SCE_0dot1_InspectingEventDocument1.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "allOf": [
+    {
+      "$ref": "https://ref.gs1.org/standards/epcis/epcis-json-schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "EPCISDocument"
+        },
+        "epcisBody": {
+          "type": "object",
+          "properties": {
+            "eventList": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "TransactionEvent"
+                    ]
+                  },
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "ADD"
+                    ]
+                  },
+                  "eventID": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*:.*"
+                  },
+                  "epcList": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/8003\\/\\d{14}([a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,16}$"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "urn:epc:id:grai:(?:\\d{6}\\.\\d{6}|\\d{7}\\.\\d{5}|\\d{8}\\.\\d{4}|\\d{9}\\.\\d{3}|\\d{10}\\.\\d{2}|\\d{11}\\.\\d{1}|\\d{12}\\..)(\\%2[125-9A-Fa-f]|\\%3[0-9A-Fa-f]|\\%4[1-9A-Fa-f]|\\%5[0-9AaFf]|\\%6[1-9A-Fa-f]|\\%7[0-9Aa]|[!')(*+,.0-9:;=A-Za-z_-]){1,16}$"
+                        }
+                      ]
+                    },
+                    "minItems": 1
+                  },
+                  "readPoint": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/414\\/\\d{13}(\\/254\\/([a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,20})?$"
+                      }
+                    },
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  "bizStep": {
+                    "type": "string",
+                    "enum": [
+                      "inspecting"
+                    ]
+                  },
+                  "disposition": {
+                    "type": "string",
+                    "enum": [
+                      "conformant",
+                      "non_conformant"
+                    ]
+                  },
+                  "bizTransactionList": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "testres"
+                          ]
+                        },
+                        "bizTransaction": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "bizTransaction"
+                      ]
+                    },
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "action",
+                  "eventID",
+                  "epcList",
+                  "readPoint",
+                  "bizStep",
+                  "disposition",
+                  "bizTransactionList"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "required": [
+            "eventList"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "epcisBody"
+      ],
+      "additionalProperties": true
+    }
+  ]
+}

--- a/json-schema-epcis-profiles/ACME_ES_SCE_0dot1_ReplacementEventDocument1.json
+++ b/json-schema-epcis-profiles/ACME_ES_SCE_0dot1_ReplacementEventDocument1.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "allOf": [
+    {
+      "$ref": "https://ref.gs1.org/standards/epcis/epcis-json-schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "EPCISDocument"
+        },
+        "epcisBody": {
+          "type": "object",
+          "properties": {
+            "eventList": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "AssociationEvent"
+                    ]
+                  },
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "ADD",
+                      "DELETE"
+                    ]
+                  },
+                  "parentID": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/414\\/\\d{13}(\\/254\\/([a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,20})?$"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/8003\\/\\d{14}([a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,16}$"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/253\\/\\d{13}([a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,17}$"
+                      }
+                    ]
+                  },
+                  "childEPCs": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/01\\/\\d{14}\\/21\\/([a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,20}$"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/8006\\/\\d{18}\\/21\\/([a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,20}$"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/8010\\/\\d{4}(?:[A-Z0-9-]|%2[3fF]){1,26}\\/8011\\/\\d{1,12}$"
+                        },
+                        {
+                          "type": "string",
+                          "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/8004\\/\\d{4}(?:[a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,26}$"
+                        }
+                      ]
+                    }
+                  },
+                  "readPoint": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "pattern": "^https?:\\/\\/([^\\/?#:]+)(:([0-9]*))?(\\/[^?#]*)*\\/414\\/\\d{13}(\\/254\\/([a-zA-Z0-9_\".-]|%2[a-cA-CfF15-9]|%3[a-fA-F]){1,20})?$"
+                      }
+                    },
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  "bizStep": {
+                    "type": "string",
+                    "enum": [
+                      "installing",
+                      "removing"
+                    ]
+                  },
+                  "bizTransactionList": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "pattern": "^https://example.com/btt/replorder$"
+                        },
+                        "bizTransaction": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "bizTransaction"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "type",
+                  "action",
+                  "parentID",
+                  "childEPCs",
+                  "readPoint",
+                  "bizStep",
+                  "bizTransactionList"
+                ],
+                "additionalProperties": true
+              }
+            }
+          },
+          "required": [
+            "eventList"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "epcisBody"
+      ],
+      "additionalProperties": true
+    }
+  ]
+}


### PR DESCRIPTION
Dear @Aravinda93 , 

Thanks for adding support for adding profiles through this way. 

I've added an illustrative *example* profile for an AssociationEvent and a TransactionEvent. So, we now have one (ACME) example for each event type. 

BTW: If we want to provide a tutorial or other supporting material, I am happ to contribute the EPCIS events I created to test against these profiles.  

@sboeckelmann : FYI

Kind regards,
Ralph 